### PR TITLE
[local] Bump to go 1.21 in tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ include: https://gitlab-templates.ddbuild.io/compute-delivery/v2/compute-deliver
 test:
   stage: verify
   tags: [ "arch:amd64" ]
-  image: registry.ddbuild.io/images/mirror/golang:1.20
+  image: registry.ddbuild.io/images/mirror/golang:1.21
   script:
     - make test-go test-vet test-fmt
 


### PR DESCRIPTION
Bump go in our own gitlab tests