### PR TITLE
[snapshot-controller] Do not modify error when retrying PVC finalizer removal

### DIFF
--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -931,7 +931,7 @@ func (ctrl *csiSnapshotCommonController) ensurePVCFinalizer(snapshot *crdv1.Volu
 
 // removePVCFinalizer removes a Finalizer for VolumeSnapshot Source PVC.
 func (ctrl *csiSnapshotCommonController) removePVCFinalizer(pvc *v1.PersistentVolumeClaim) error {
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		// Get snapshot source which is a PVC
 		newPvc, err := ctrl.client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
 		if err != nil {
@@ -941,12 +941,16 @@ func (ctrl *csiSnapshotCommonController) removePVCFinalizer(pvc *v1.PersistentVo
 		newPvc.ObjectMeta.Finalizers = utils.RemoveString(newPvc.ObjectMeta.Finalizers, utils.PVCFinalizer)
 		_, err = ctrl.client.CoreV1().PersistentVolumeClaims(newPvc.Namespace).Update(context.TODO(), newPvc, metav1.UpdateOptions{})
 		if err != nil {
-			return newControllerUpdateError(newPvc.Name, err.Error())
+			return err
 		}
 
 		klog.V(5).Infof("Removed protection finalizer from persistent volume claim %s", pvc.Name)
 		return nil
 	})
+	if err != nil {
+		return newControllerUpdateError(pvc.Name, err.Error())
+	}
+	return nil
 }
 
 // isPVCBeingUsed checks if a PVC is being used as a source to create a snapshot.


### PR DESCRIPTION

**What this PR does / why we need it**:

The `RetryOnConflict` function only retries the update of an object if the retured error is an unmodified 429 error. This commit fixes the retry to modify the error into a `controllerUpdateError` only after the `RetryOnConflict` function finishes.
